### PR TITLE
Issue #26

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,6 +45,12 @@
                 android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
                 android:resource="@xml/device_filter" />
         </activity>
+        <activity
+            android:name="com.github.mjdev.libaums.test.LibAumsTest">
+            <meta-data
+                android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
+                android:resource="@xml/device_filter" />
+        </activity>
         <service android:name="com.github.mjdev.libaums.server.http.UsbFileHttpServerService" />
     </application>
 

--- a/app/src/main/java/com/github/mjdev/libaums/test/LibAumsTest.java
+++ b/app/src/main/java/com/github/mjdev/libaums/test/LibAumsTest.java
@@ -1,0 +1,320 @@
+package com.github.mjdev.libaums.test;
+
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbManager;
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
+
+import com.github.mjdev.libaums.UsbMassStorageDevice;
+import com.github.mjdev.libaums.fs.FileSystem;
+import com.github.mjdev.libaums.fs.UsbFile;
+
+import java.io.IOException;
+
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertTrue;
+
+/**
+ * Add activity to AndroidManifest.xml and start from there to run tests
+ *
+ * When debugging applications that use USB accessory or host features, you most likely will have
+ * USB hardware connected to your Android-powered device. This will prevent you from having an adb
+ * connection to the Android-powered device via USB. You can still access adb over a network
+ * connection. To enable adb over a network connection:
+ *
+ * Connect the Android-powered device via USB to your computer.
+ *
+ * From your SDK platform-tools/ directory, enter adb tcpip 5555 at the command prompt.
+ *
+ * To get device-ip-address type 'adb shell ifconfig'
+ *
+ * Enter adb connect <device-ip-address>:5555 You should now be connected to the Android-powered
+ * device and can issue the usual adb commands like adb logcat.
+ *
+ * To set your device to listen on USB, enter adb usb.
+ *
+ * Created by nowell on 26/04/16.
+ */
+public class LibAumsTest extends AppCompatActivity {
+
+    private static final String TAG = LibAumsTest.class.getSimpleName();
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+
+        super.onCreate(savedInstanceState);
+
+        IntentFilter filter = new IntentFilter(ACTION_USB_PERMISSION);
+        filter.addAction(UsbManager.ACTION_USB_DEVICE_ATTACHED);
+        filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
+        registerReceiver(usbReceiver, filter);
+        discoverDevice();
+    }
+
+    /**
+     * Action string to request the permission to communicate with an UsbDevice.
+     */
+    private static final String ACTION_USB_PERMISSION = "com.github.mjdev.libaums.USB_PERMISSION";
+
+    private UsbMassStorageDevice device;
+
+    private FileSystem fs;
+
+    /**
+     * run all tests on the usb mass storage device
+     */
+    private void runAll() {
+
+        try {
+
+            testCreateFile();
+
+            testCreateDirectory();
+
+            testSearchAndCreateFile();
+
+            testSearchAndCreateDirectory();
+
+            Log.d(TAG, "PASS");
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            Log.d(TAG, "FAIL");
+        }
+
+    }
+
+    private void testCreateFile()
+            throws IOException {
+
+        UsbFile root = fs.getRootDirectory();
+
+        UsbFile testDirectory = root.search("testCreateFile");
+        if(testDirectory != null) {
+            testDirectory.delete();
+        }
+
+        testDirectory = root.createDirectory("testCreateFile");
+
+        testDirectory.createDirectory("testFile1");
+
+        testDirectory.createDirectory("testFile2");
+
+        UsbFile[] files = testDirectory.listFiles();
+
+        assertTrue((files != null) && (files.length == 2));
+
+        testDirectory.delete();
+
+    }
+
+    private void testCreateDirectory()
+            throws IOException {
+
+        UsbFile root = fs.getRootDirectory();
+
+        UsbFile testDirectory = root.search("testCreateDirectory");
+        if(testDirectory != null) {
+            testDirectory.delete();
+        }
+
+        testDirectory = root.createDirectory("testCreateDirectory");
+
+        testDirectory.createDirectory("testDirectory1");
+
+        testDirectory.createDirectory("testDirectory2");
+
+        UsbFile[] files = testDirectory.listFiles();
+
+        assertTrue((files != null) && (files.length == 2));
+
+        testDirectory.delete();
+
+    }
+
+    /**
+     * test fix for issue #36 in v0.3
+     * search followed by createFile causes loss of all other files in same directory
+     *
+     *
+     * @throws IOException
+     */
+    private void testSearchAndCreateFile()
+            throws IOException {
+
+        UsbFile root = fs.getRootDirectory();
+
+        UsbFile testDirectory = root.search("testSearchAndCreateFile");
+        if(testDirectory != null) {
+            testDirectory.delete();
+        }
+
+        // create non-empty directory
+
+        testDirectory = root.createDirectory("testSearchAndCreateFile");
+
+        testDirectory.createDirectory("testDirectory1");
+
+        // search and create new sub-directory
+
+        UsbFile searchDirectory = root.search("testSearchAndCreateFile");
+        assertNotNull(searchDirectory);
+
+        searchDirectory.createDirectory("testDirectory2");
+
+        // count number of files in directory, should be two
+
+        UsbFile[] files = searchDirectory.listFiles();
+        assertTrue((files != null) && (files.length == 2));
+
+        testDirectory.delete();
+
+    }
+
+    /**
+     * test fix for issue #36 in v0.3
+     * search followed by createDirectory causes loss of all other files in same directory
+     *
+     * @throws IOException
+     */
+    private void testSearchAndCreateDirectory()
+            throws IOException {
+
+        UsbFile root = fs.getRootDirectory();
+
+        UsbFile testDirectory = root.search("testSearchAndCreateDirectory");
+        if(testDirectory != null) {
+            testDirectory.delete();
+        }
+
+        // create non-empty directory
+
+        testDirectory = root.createDirectory("testSearchAndCreateDirectory");
+
+        testDirectory.createDirectory("testDirectory1");
+
+        // search and create new sub-directory
+
+        UsbFile searchDirectory = root.search("testSearchAndCreateDirectory");
+        assertNotNull(searchDirectory);
+
+        searchDirectory.createDirectory("testDirectory2");
+
+        // count number of files in directory, should be two
+
+        UsbFile[] files = searchDirectory.listFiles();
+        assertTrue((files != null) && (files.length == 2));
+
+        testDirectory.delete();
+
+    }
+
+    /**
+     * Searches for connected mass storage devices, and initializes them if it
+     * could find some.
+     */
+    private void discoverDevice() {
+
+        UsbManager usbManager = (UsbManager) getSystemService(Context.USB_SERVICE);
+
+        UsbMassStorageDevice[] devices = UsbMassStorageDevice.getMassStorageDevices(this);
+
+        // we only use the first device
+        device = devices[0];
+
+        UsbDevice usbDevice = getIntent().getParcelableExtra(UsbManager.EXTRA_DEVICE);
+
+        if (usbDevice != null && usbManager.hasPermission(usbDevice)) {
+
+            Log.d(TAG, "received usb device via intent");
+            // requesting permission is not needed in this case
+            setupDevice();
+
+        } else {
+
+            // first request permission from user to communicate with the
+            // underlying
+            // UsbDevice
+            PendingIntent permissionIntent = PendingIntent.getBroadcast(this, 0, new Intent(
+                    ACTION_USB_PERMISSION), 0);
+            usbManager.requestPermission(device.getUsbDevice(), permissionIntent);
+
+        }
+
+    }
+
+    /**
+     * Sets the device up and shows the contents of the root directory.
+     */
+    private void setupDevice() {
+
+        try {
+
+            device.init();
+
+            fs = device.getPartitions().get(0).getFileSystem();
+
+            runAll();
+
+        } catch (IOException e) {
+            Log.e(TAG, "error setting up device", e);
+        }
+
+    }
+
+    private final BroadcastReceiver usbReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+
+            String action = intent.getAction();
+
+            if (ACTION_USB_PERMISSION.equals(action)) {
+
+                UsbDevice device = intent.getParcelableExtra(UsbManager.EXTRA_DEVICE);
+
+                if (intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false)) {
+
+                    if (device != null) {
+                        setupDevice();
+                    }
+
+                }
+
+            } else if (UsbManager.ACTION_USB_DEVICE_ATTACHED.equals(action)) {
+                UsbDevice device = intent.getParcelableExtra(UsbManager.EXTRA_DEVICE);
+
+                Log.d(TAG, "USB device attached");
+
+                // determine if connected device is a mass storage devuce
+                if (device != null) {
+                    discoverDevice();
+                }
+
+            } else if (UsbManager.ACTION_USB_DEVICE_DETACHED.equals(action)) {
+
+                UsbDevice device = intent.getParcelableExtra(UsbManager.EXTRA_DEVICE);
+
+                Log.d(TAG, "USB device detached");
+
+                // determine if connected device is a mass storage devuce
+                if (device != null) {
+                    if (LibAumsTest.this.device != null) {
+                        LibAumsTest.this.device.close();
+                    }
+                    // check if there are other devices or set action bar title
+                    // to no device if not
+                    discoverDevice();
+                }
+
+            }
+
+        }
+    };
+
+}

--- a/app/src/main/java/com/github/mjdev/libaums/test/LibAumsTest.java
+++ b/app/src/main/java/com/github/mjdev/libaums/test/LibAumsTest.java
@@ -93,6 +93,8 @@ public class LibAumsTest extends AppCompatActivity {
     private void testCreateFile()
             throws IOException {
 
+        UsbFile[] files;
+
         UsbFile root = fs.getRootDirectory();
 
         UsbFile testDirectory = root.search("testCreateFile");
@@ -101,13 +103,14 @@ public class LibAumsTest extends AppCompatActivity {
         }
 
         testDirectory = root.createDirectory("testCreateFile");
+        files = testDirectory.listFiles();
+        assertTrue((files != null) && (files.length == 0));
 
         testDirectory.createDirectory("testFile1");
 
         testDirectory.createDirectory("testFile2");
 
-        UsbFile[] files = testDirectory.listFiles();
-
+        files = testDirectory.listFiles();
         assertTrue((files != null) && (files.length == 2));
 
         testDirectory.delete();

--- a/app/src/main/java/com/github/mjdev/libaums/usbfileman/MainActivity.java
+++ b/app/src/main/java/com/github/mjdev/libaums/usbfileman/MainActivity.java
@@ -68,6 +68,7 @@ import com.github.mjdev.libaums.fs.FileSystem;
 import com.github.mjdev.libaums.fs.UsbFile;
 import com.github.mjdev.libaums.server.http.UsbFileHttpServer;
 import com.github.mjdev.libaums.server.http.UsbFileHttpServerService;
+import com.github.mjdev.libaums.test.LibAumsTest;
 
 /**
  * MainActivity of the demo application which shows the contents of the first
@@ -473,6 +474,9 @@ public class MainActivity extends AppCompatActivity implements OnItemClickListen
                 serverService.stopServer();
             }
             return true;
+		case R.id.run_tests:
+			startActivity(new Intent(this, LibAumsTest.class));
+			return true;
 		default:
 			return super.onOptionsItemSelected(item);
 		}

--- a/app/src/main/res/menu/main.xml
+++ b/app/src/main/res/menu/main.xml
@@ -40,4 +40,9 @@
         android:title="@string/stop_http_server">
     </item>
 
+    <item
+        android:id="@+id/run_tests"
+        android:title="@string/run_tests">
+    </item>
+
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,4 +32,5 @@
     <string name="file">File</string>
     <string name="start_http_server">Serve via HTTP Server</string>
     <string name="stop_http_server">Stop HTTP Server</string>
+    <string name="run_tests">Run tests</string>
 </resources>

--- a/libaums/src/main/java/com/github/mjdev/libaums/fs/fat32/FatDirectory.java
+++ b/libaums/src/main/java/com/github/mjdev/libaums/fs/fat32/FatDirectory.java
@@ -137,8 +137,7 @@ public class FatDirectory implements UsbFile {
 		FatDirectory result = new FatDirectory(blockDevice, fat, bootSector, null);
 		result.chain = new ClusterChain(bootSector.getRootDirStartCluster(), blockDevice, fat,
 				bootSector);
-		result.init();
-		result.readEntries();
+		result.init(); // init calls readEntries
 		return result;
 	}
 


### PR DESCRIPTION
Added missing init() to createFile and createDirectory
Moved the allocation of entries field to init() so that the field is allocated and initialised at the same time,
this prevents use of uninitialised entries and potential data loss
Added some unit tests and options menu to run.

I've successfully tested these changes a few times but seem to have a corrupted usb drive, I think caused by interrupting the execution or removing usb drive at the wrong time. Now I am having another problem whereby created directories are not empty but contain numerous junk files.
Unfortunately I don't have more time to spend on that right now.