### PR TITLE
Ci instrumented tests

### DIFF
--- a/.ci_helpers/download_android-x86.py
+++ b/.ci_helpers/download_android-x86.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import subprocess
+import sys
+import traceback
+
+api_links = {
+    1: {
+        'iso': [
+            'https://osdn.net/frs/redir.php?m=dotsrc&f=android-x86%2F65700%2Feeepc-v0.9.iso'
+        ]
+    },
+    # Donut EeePC
+    4: {
+        'iso': [
+            'https://osdn.net/frs/redir.php?m=dotsrc&f=android-x86%2F65699%2Fandroid-x86-1.6-r2.iso'
+        ]
+    },
+    # Froyo EeePC
+    8: {
+        'iso': [
+            'https://osdn.net/frs/redir.php?m=dotsrc&f=android-x86%2F65698%2Fandroid-x86-2.2-r2-eeepc.iso'
+        ]
+    },
+    # Ice Cream Sandwich EeePC
+    14: {
+        'iso': [
+            'https://osdn.net/frs/redir.php?m=dotsrc&f=android-x86%2F66419%2Fandroid-x86-4.0-r1-eeepc.iso'
+        ]
+    },
+    # KitKat
+    19: {
+        'iso': [
+            'https://osdn.net/frs/redir.php?m=dotsrc&f=android-x86%2F65695%2Fandroid-x86-4.4-r5.iso'
+        ]
+    },
+    # Lollipop
+    22: {
+        'iso': [
+            'https://osdn.net/frs/redir.php?m=dotsrc&f=android-x86%2F65697%2Fandroid-x86_64-5.1-rc1.img'
+        ]
+    },
+    # Marshmallow
+    23: {
+        'iso': [
+            'https://osdn.net/projects/android-x86/downloads/65890/android-x86_64-6.0-r3.iso/'
+        ],
+        'rpm': [
+            'https://osdn.net/frs/redir.php?m=dotsrc&f=android-x86%2F65890%2Fandroid-x86-6.0-r3.x86_64.rpm'
+        ]
+    },
+    # Nougat
+    25: {
+        'iso': [
+            'https://osdn.net/frs/redir.php?m=dotsrc&f=android-x86%2F67834%2Fandroid-x86_64-7.1-r4.iso',
+            'https://www.fosshub.com/Android-x86-old.html?dwl=android-x86_64-7.1-r4.iso'
+        ],
+        'rpm': [
+            'https://osdn.net/frs/redir.php?m=dotsrc&f=android-x86%2F67834%2Fandroid-x86-7.1-r4.x86_64.rpm',
+            'https://www.fosshub.com/Android-x86-old.html?dwl=android-x86-7.1-r4.x86_64.rpm'
+        ]
+    },
+    # Oreo
+    27: {
+        'iso': [
+            'https://osdn.net/frs/redir.php?m=dotsrc&f=android-x86%2F69704%2Fandroid-x86_64-8.1-r5.iso',
+            'https://www.fosshub.com/Android-x86-old.html?dwl=android-x86_64-8.1-r5.iso'
+        ],
+        'rpm': [
+            'https://osdn.net/frs/redir.php?m=dotsrc&f=android-x86%2F69704%2Fandroid-x86-8.1-r5.x86_64.rpm',
+            'https://www.fosshub.com/Android-x86-old.html?dwl=android-x86-8.1-r5.x86_64.rpm'
+        ]
+    },
+    # Pie
+    28: {
+        'iso': [
+            'https://osdn.net/frs/redir.php?m=dotsrc&f=android-x86%2F71931%2Fandroid-x86_64-9.0-r2.iso',
+            'https://www.fosshub.com/Android-x86.html?dwl=android-x86_64-9.0-r2.iso'
+        ],
+        'rpm': [
+            'https://osdn.net/frs/redir.php?m=dotsrc&f=android-x86%2F71931%2Fandroid-x86-9.0-r2.x86_64.rpm',
+            'https://www.fosshub.com/Android-x86.html?dwl=android-x86-9.0-r2.x86_64.rpm'
+        ]
+    }
+}
+
+
+def list():
+    for api, links in api_links.items():
+        print(f"{api}: {','.join(links.keys())}")
+
+
+def usage():
+    print(f"Usage: {sys.argv[0]} [-h|--help] | [-l|--list] | <iso|rpm> <api number> [filename]")
+    sys.exit(1)
+
+
+def main():
+    if len(sys.argv) < 2 or sys.argv[1] in ('-h', '--helo'):
+        usage()
+    if sys.argv[1] in ('-l', '--list'):
+        list()
+        return
+
+    try:
+        img_type = sys.argv[1]
+        if img_type not in ('iso', 'rpm'):
+            raise ValueError(f"Invalid format: '{img_type}'")
+        api = int(sys.argv[2])
+        if len(sys.argv) > 3:
+            filename = sys.argv[3]
+        else:
+            filename = f"android_x86-{api}.{img_type}"
+    except (KeyError, ValueError):
+        traceback.print_exc()
+        usage()
+        return
+
+    for link in api_links[api][img_type]:
+        try:
+            subprocess.run(['wget', link, '-qO', filename])
+            break
+        except Exception:
+            traceback.print_exc()
+    else:
+        raise RuntimeError("All links failed to download")
+
+
+if __name__ == "__main__":
+    main()

--- a/.ci_helpers/instrumented_tests_qemu.sh
+++ b/.ci_helpers/instrumented_tests_qemu.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+if type travis_retry >/dev/null 2>&1; then
+  alias retry=travis_retry
+else
+  function retry() {
+    for i in {1..3}; do
+      "$@" && return 0 || echo "Command failed, attempt $i / 3" >&2
+    done
+    return 1
+  }
+fi
+
+set -e
+
+api="$1"
+
+export JOB_WORKDIR="$(pwd)"
+
+if [ "$VIRTWIFI_HACK" != 0 ]; then
+  echo "Downloading VirtWifi connector..."
+  [ -f "virtwificonnector.apk" ] || retry wget -qO virtwificonnector.apk "$(curl -s https://api.github.com/repos/EtchDroid/VirtWifiConnector/releases/latest | grep 'virtwificonnector-debug.apk' | grep download | cut -d '"' -f 4)"
+  export VIRTWIFICONNECTOR_APK="$(pwd)/virtwificonnector.apk"
+fi
+
+echo "Downloading Android-x86 SDK$api image..."
+[ -f "android.rpm" ] || retry ./.ci_helpers/download_android-x86.py rpm "$api" "android.rpm"
+
+echo "Extracting files..."
+[ -d "android-*" ] || rpm2cpio "android.rpm" | bsdtar -xf -
+
+cd android-*   # A-x86 RPMs contain a directory named android-[release] with the images
+
+echo "Creating emulated USB drive"
+[ -f "usb.img" ] && rm usb.img
+qemu-img create -f raw usb.img 4G
+
+sfdisk usb.img << EOF
+label: dos
+label-id: 0x3ffe7587
+device: usb.img
+unit: sectors
+
+usb.img1 : start=        2048, size=     8386560, type=83
+EOF
+
+sudo losetup -P /dev/loop20 usb.img
+sudo mkfs.msdos /dev/loop20p1
+sudo losetup -d /dev/loop20
+
+set +e
+
+echo "Starting tests"
+python3 -m qemu_android_test_orchestrator
+retcode=$?
+
+echo "Cleaning up"
+cd ..
+sudo rm -Rf android-* usr android.rpm
+
+exit "$retcode"

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -19,3 +19,7 @@ jobs:
       run: echo "libusb.dir=$GITHUB_WORKSPACE/libusb-1.0.23" > $GITHUB_WORKSPACE/local.properties
     - name: Build with Gradle
       run: ./gradlew build
+    - name: coverage report
+      run: ./gradlew build -x bintray jacocoTestReport --stacktrace
+    - name: codecov
+      run: bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,93 @@
-language: android
-jdk: oraclejdk8
-dist: trusty
-sudo: required
+language: bash
+os: linux
+dist: focal
 group: edge
-
-android:
-  components:
-    - tools
-    - android-26
-
-install:
-  - sudo apt-get install build-essential
-  - yes | sdkmanager 'ndk-bundle'
-  - yes | sdkmanager 'cmake;3.6.4111459'
 
 env:
   global:
-   # install timeout in minutes (2 minutes by default)
+    # Android/Java stuff
     - ADB_INSTALL_TIMEOUT=8
+    - ANDROID_HOME=${HOME}/android-sdk
+    - ANDROID_TOOLS_URL="https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip"
+    - TOOLS=${ANDROID_HOME}/tools
+    - PATH=${ANDROID_HOME}:${ANDROID_HOME}/emulator:${TOOLS}:${TOOLS}/bin:${ANDROID_HOME}/platform-tools:/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64/bin:/usr/lib/jvm/adoptopenjdk-8-hotspot-jre-amd64/bin:${PATH}
+    - TERM=dumb
+    # QEMU orchestrator
+    - QEMU_DEBUG=1
+    - PYTHONUNBUFFERED=1
+    - JOB_COMMAND="./gradlew androidtests:connectedAndroidTest"
+    - VNC_RECORDER=1
+    - VNC_RECORDER_BIN=/usr/local/bin/vnc-recorder
+    - VNC_RECORDER_OUTPUT="$TRAVIS_BUILD_DIR/screenrec.mkv"
+    - LOGCAT_OUTPUT="$TRAVIS_BUILD_DIR/logcat.txt"
+    - DMESG_OUTPUT="$TRAVIS_BUILD_DIR/dmesg.txt"
+    - BUGREPORT_OUTPUT="$TRAVIS_BUILD_DIR/bugreport.zip"
+  matrix:
+    # Note to readers: do not "fill the gaps": Android-x86 RPM images are not available for all versions.
+    # Make sure new ones are added first to the download script and test them.
+    - API=23 VIRTWIFI_HACK=0 API_NAME=marshmallow
+    - API=25 VIRTWIFI_HACK=1 API_NAME=nougat
+    - API=27 VIRTWIFI_HACK=1 API_NAME=oreo
+    - API=28 VIRTWIFI_HACK=1 API_NAME=pie
+
+before_install:
+  - free -h
+  # AdoptOpenJDK
+  - travis_retry sudo apt-get update
+  - sudo apt-get install -y software-properties-common
+  - travis_retry wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | sudo apt-key add -
+  - travis_retry sudo add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
+  - travis_retry sudo apt-get update
+  - travis_retry sudo apt-get install -y java-common adoptopenjdk-8-hotspot adoptopenjdk-8-hotspot-jre
+  # Android SDK
+  - travis_retry wget -q "${ANDROID_TOOLS_URL}" -O android-sdk-tools.zip
+  - unzip -q android-sdk-tools.zip -d ${ANDROID_HOME}
+  - rm android-sdk-tools.zip
+  - mkdir ~/.android  # avoid harmless sdkmanager warning
+  - echo 'count=0' > ~/.android/repositories.cfg  # avoid harmless sdkmanager warning
+  - yes | travis_retry sdkmanager --licenses >/dev/null  # accept all sdkmanager warnings
+  - yes | travis_retry sdkmanager --no_https "platform-tools" >/dev/null
+  - yes | travis_retry sdkmanager --no_https "tools" >/dev/null  # A second time per Travis docs, gets latest versions
+  - yes | travis_retry sdkmanager --no_https "build-tools;28.0.3" >/dev/null  # Implicit gradle dependency - gradle drives changes
+  - yes | travis_retry sdkmanager --no_https "platforms;android-29" >/dev/null  # We need the API of the current compileSdkVersion from gradle.properties
+  - yes | travis_retry sdkmanager 'ndk-bundle' >/dev/null
+  - yes | travis_retry sdkmanager 'cmake;3.6.4111459' >/dev/null
+
+install:
+  # qemu
+  - travis_retry sudo apt-get install --no-install-suggests --no-install-recommends -y build-essential qemu-system qemu-utils libvirt-clients fdisk python3 python3-pip python3-setuptools dosfstools rpm2cpio libarchive-tools adb ffmpeg git libpulse0 libvirt0 libvirt-daemon qemu-kvm virtinst
+  # Debug KVM availability
+  - cat /proc/cpuinfo
+  - lscpu
+  - sudo virt-host-validate || echo "virt-host-validate exited with $? non-zero status code"
+  # orchestrator
+  - travis_retry sudo pip3 install https://github.com/EtchDroid/qemu_test_orchestrator/archive/master.zip
+  # vnc-recorder
+  - travis_retry sudo wget "https://github.com/Depau/vnc-recorder/releases/download/v0.2/vnc-recorder-linux-x86_64.bin" -O /usr/local/bin/vnc-recorder
+  - sudo chmod +x /usr/local/bin/vnc-recorder
+  # minio client
+  - travis_retry sudo wget "https://dl.min.io/client/mc/release/linux-amd64/mc" -O /usr/local/bin/mc
+  - sudo chmod +x /usr/local/bin/mc
+  # Try loading kvm module
+  - sudo modprobe kvm || echo "Unable to load KVM module"
 
 before_script:
+  # libusb
   - ls
-  - wget https://github.com/libusb/libusb/archive/v1.0.23.zip
-  - unzip v1.0.23.zip
+  - wget -q https://github.com/libusb/libusb/archive/v1.0.23.zip
+  - unzip -q v1.0.23.zip
   - echo "libusb.dir=$TRAVIS_BUILD_DIR/libusb-1.0.23" > $TRAVIS_BUILD_DIR/local.properties
 
 script:
-  - ./gradlew build -x bintray jacocoTestReport --stacktrace
+  # Run VM and tests
+  - sudo -E ./.ci_helpers/instrumented_tests_qemu.sh "$API"
 
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
+after_script:
+  # Upload screen recording
+  - sudo chown "$USER" "$VNC_RECORDER_OUTPUT"
+  - mc config host add minio "$MINIO_SERVER" "$MINIO_USER" "$MINIO_TOKEN"
+  - travis_retry mc cp "$VNC_RECORDER_OUTPUT" "minio/libaums-screenrecs/travis/$TRAVIS_BUILD_NUMBER/sdk$API-$API_NAME/screen_rec.mkv"
+  - travis_retry mc cp "$LOGCAT_OUTPUT" "minio/libaums-screenrecs/travis/$TRAVIS_BUILD_NUMBER/sdk$API-$API_NAME/logcat.txt"
+  - travis_retry mc cp "$DMESG_OUTPUT" "minio/libaums-screenrecs/travis/$TRAVIS_BUILD_NUMBER/sdk$API-$API_NAME/dmesg.txt"
+  - travis_retry mc cp "$BUGREPORT_OUTPUT" "minio/libaums-screenrecs/travis/$TRAVIS_BUILD_NUMBER/sdk$API-$API_NAME/bugreport.zip"
+  - 'echo "Build logs and screen recording at $MINIO_SERVER/minio/libaums-screenrecs/travis/$TRAVIS_BUILD_NUMBER/sdk$API-$API_NAME/"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
     # Note to readers: do not "fill the gaps": Android-x86 RPM images are not available for all versions.
     # Make sure new ones are added first to the download script and test them.
     - API=23 VIRTWIFI_HACK=0 API_NAME=marshmallow
-    - API=25 VIRTWIFI_HACK=1 API_NAME=nougat
+    #- API=25 VIRTWIFI_HACK=1 API_NAME=nougat   # Gets stuck
     - API=27 VIRTWIFI_HACK=1 API_NAME=oreo
     - API=28 VIRTWIFI_HACK=1 API_NAME=pie
 

--- a/androidtests/build.gradle
+++ b/androidtests/build.gradle
@@ -28,6 +28,11 @@ android {
         }
     }
 
+    adbOptions {
+        timeOutInMs 10 * 60 * 1000  // 10 minutes
+        installOptions "-d","-t"
+    }
+
     useLibrary 'android.test.runner'
     useLibrary 'android.test.base'
     useLibrary 'android.test.mock'

--- a/androidtests/src/androidTest/java/me/jahnen/libaums/androidtests/LibAumsTest.kt
+++ b/androidtests/src/androidTest/java/me/jahnen/libaums/androidtests/LibAumsTest.kt
@@ -28,8 +28,8 @@ import org.junit.runners.Parameterized
 import java.io.IOException
 import java.util.concurrent.TimeoutException
 
-private const val USB_DISCOVER_TIMEOUT = 30 * 1000
-private const val USB_PERMISSION_TIMEOUT = 30 * 1000
+private const val USB_DISCOVER_TIMEOUT = 120 * 1000
+private const val USB_PERMISSION_TIMEOUT = 120 * 1000
 
 @RunWith(Parameterized::class)
 @LargeTest


### PR DESCRIPTION
This introduces QEMU tests on GitHub Actions. Since GH Actions doesn't support nested virtualization but Travis does, but also Travis doesn't support multiple workflows, I would convert the existing travis..yml to GH Actions and this to Travis.

To get over all of the Android image shenanigans such as "does not connect to the emulated network" or "no way to auto-approve USB permissions" I'm pulling in two other projects. I added them to the EtchDroid organization but let me know if you have a better place for them (if you like them at all):

- https://github.com/EtchDroid/qemu_test_orchestrator
  - The name should be pretty clear, it runs VM, applies all the workarounds and runs the tests inside of it, while approving permission requests
- https://github.com/EtchDroid/VirtWifiConnector/
  - All "usable" Android-x86 images except for Marshmallow do not connect to the network automatically. They instead show the emulated ethernet as "VirtWifi" and they do not connect to it automatically. It turns out there's no easy way to connect to wifi from the command line, so the orchestrator above will take an APK of this small helper and shove it into QEMU over the emulated serial

I followed this approach in order to be able to use upstream, clean Android-x86 images. I wanted to avoid having to build a purpose-made image. It works on all images for which an RPM package is provided (API 23, 25, 27, 28).