### PR TITLE
Prevent communication usage after closing

### DIFF
--- a/libaums/src/main/java/me/jahnen/libaums/core/usb/AndroidUsbCommunication.kt
+++ b/libaums/src/main/java/me/jahnen/libaums/core/usb/AndroidUsbCommunication.kt
@@ -17,7 +17,7 @@ internal abstract class AndroidUsbCommunication(
 
     private var isNativeInited: Boolean = false
     var deviceConnection: UsbDeviceConnection? = null
-    private var isClosed = false
+    protected var isClosed = false
 
     init {
         initNativeLibrary()
@@ -49,10 +49,14 @@ internal abstract class AndroidUsbCommunication(
     }
 
     override fun controlTransfer(requestType: Int, request: Int, value: Int, index: Int, buffer: ByteArray, length: Int): Int {
+        require(!isClosed) { "device is closed" }
+
         return deviceConnection!!.controlTransfer(requestType, request, value, index, buffer, length, TRANSFER_TIMEOUT)
     }
 
     override fun resetDevice() {
+        require(!isClosed) { "device is closed" }
+
         Log.d(TAG, "Performing native reset")
 
         if (!deviceConnection!!.releaseInterface(usbInterface)) {
@@ -70,6 +74,8 @@ internal abstract class AndroidUsbCommunication(
     }
 
     override fun clearFeatureHalt(endpoint: UsbEndpoint) {
+        require(!isClosed) { "device is closed" }
+
         Log.w(TAG, "Clearing halt on endpoint $endpoint (direction ${endpoint.direction})")
         val result = clearHaltNative(deviceConnection!!.fileDescriptor, endpoint.address)
         if (!result) {
@@ -90,6 +96,8 @@ internal abstract class AndroidUsbCommunication(
     }
 
     override fun close() {
+        require(!isClosed) { "device is already closed" }
+
         Log.d(TAG, "close device")
         closeUsbConnection()
         isClosed = true

--- a/libaums/src/main/java/me/jahnen/libaums/core/usb/HoneyCombMr1Communication.kt
+++ b/libaums/src/main/java/me/jahnen/libaums/core/usb/HoneyCombMr1Communication.kt
@@ -25,6 +25,8 @@ internal class HoneyCombMr1Communication(
 
     @Throws(IOException::class)
     override fun bulkOutTransfer(src: ByteBuffer): Int {
+        require(!isClosed) { "device is closed" }
+
         val offset = src.position()
 
         if (offset == 0) {
@@ -54,6 +56,8 @@ internal class HoneyCombMr1Communication(
 
     @Throws(IOException::class)
     override fun bulkInTransfer(dest: ByteBuffer): Int {
+        require(!isClosed) { "device is closed" }
+
         val offset = dest.position()
 
         if (offset == 0) {

--- a/libaums/src/main/java/me/jahnen/libaums/core/usb/JellyBeanMr2Communication.kt
+++ b/libaums/src/main/java/me/jahnen/libaums/core/usb/JellyBeanMr2Communication.kt
@@ -30,6 +30,8 @@ internal class JellyBeanMr2Communication(
 
     @Throws(IOException::class)
     override fun bulkOutTransfer(src: ByteBuffer): Int {
+        require(!isClosed) { "device is closed" }
+
         val result = deviceConnection!!.bulkTransfer(outEndpoint,
                 src.array(), src.position(), src.remaining(), UsbCommunication.TRANSFER_TIMEOUT)
 
@@ -46,6 +48,8 @@ internal class JellyBeanMr2Communication(
 
     @Throws(IOException::class)
     override fun bulkInTransfer(dest: ByteBuffer): Int {
+        require(!isClosed) { "device is closed" }
+
         val result = deviceConnection!!.bulkTransfer(inEndpoint,
                 dest.array(), dest.position(), dest.remaining(), UsbCommunication.TRANSFER_TIMEOUT)
 


### PR DESCRIPTION
This is more of a workaround for poor coding in EtchDroid but I think it would be helpful to everyone anyway.

Since [I'm now uglily doing asynchronous I/O](https://github.com/EtchDroid/EtchDroid/blob/main/app/src/main/java/eu/depau/etchdroid/massstorage/BlockDeviceStreams.kt) (sort of) it sometimes happens that I throw an exception while performing an operation, close the device in the `finally` block, but meanwhile the I/O thread finishes up a `.read()` on the block device while closed causing a use-after-free inside `libusb`.

This clearly isn't great user experience.

These changes ensure that the device isn't closed before any communication is performed, throwing an `IllegalStateException` if that's not the case. It still crashes but the user experience is better than SIGSEGV :)
