### PR TITLE
Make FileBlockDeviceDriver writes sync

### DIFF
--- a/libaums/src/main/java/me/jahnen/libaums/core/driver/file/FileBlockDeviceDriver.kt
+++ b/libaums/src/main/java/me/jahnen/libaums/core/driver/file/FileBlockDeviceDriver.kt
@@ -22,7 +22,7 @@ class FileBlockDeviceDriver : BlockDeviceDriver {
     @Throws(FileNotFoundException::class)
     @JvmOverloads
     constructor(file: File, byteOffset: Int = 0, blockSize: Int = 512) {
-        this.file = RandomAccessFile(file, "rw")
+        this.file = RandomAccessFile(file, "rws")
         this.blockSize = blockSize
         this.byteOffset = byteOffset
     }
@@ -37,7 +37,7 @@ class FileBlockDeviceDriver : BlockDeviceDriver {
         val fos = FileOutputStream(tempFile)
         fos.channel.transferFrom(rbc, 0, java.lang.Long.MAX_VALUE)
 
-        this.file = RandomAccessFile(tempFile, "rw")
+        this.file = RandomAccessFile(tempFile, "rws")
         this.blockSize = blockSize
     }
 


### PR DESCRIPTION
I'm assuming `FileBlockDeviceDriver` is only used in tests.

This change makes all writes to the backing `RandomAccessFile` synchronous by opening them as `"rws"`, which will make tests more reliable.

This is not an issue with your tests, but it's a bit of a pain with the tests for my block device input/output streams.

https://docs.oracle.com/javase/7/docs/api/java/io/RandomAccessFile.html#RandomAccessFile(java.io.File,%20java.lang.String)