### PR TITLE
Handle recoverable unit attention codes

### DIFF
--- a/libaums/src/main/java/me/jahnen/libaums/core/driver/scsi/commands/sense/ScsiRequestSenseResponse.kt
+++ b/libaums/src/main/java/me/jahnen/libaums/core/driver/scsi/commands/sense/ScsiRequestSenseResponse.kt
@@ -143,7 +143,15 @@ class ScsiRequestSenseResponse private constructor() {
             MEDIUM_ERROR -> handleMediumError()
             HARDWARE_ERROR -> throw HardwareError(this)
             ILLEGAL_REQUEST -> throw IllegalCommand(this)
-            UNIT_ATTENTION -> throw UnitAttention(this)
+            UNIT_ATTENTION -> {
+                // Non-exhaustively handle recoverable unit attention conditions
+                if (additionalSenseCode.toInt() == RESET_OCCURRED ||
+                    additionalSenseCode.toInt() == COMMANDS_CLEARED) {
+                    throw NotReadyTryAgain(this)
+                } else {
+                    throw UnitAttention(this)
+                }
+            }
             DATA_PROTECT -> throw DataProtect(this)
             BLANK_CHECK -> throw BlankCheck(this)
             COPY_ABORTED -> throw CopyAborted(this)
@@ -229,5 +237,33 @@ class ScsiRequestSenseResponse private constructor() {
         const val VOLUME_OVERFLOW = 13
         const val MISCOMPARE = 14
         const val COMPLETED = 15
+
+        /**
+         * Unit attention condition additional sense code for general device reset conditions.
+         * It should be safe to handle these conditions with a retry.
+         *
+         * ASCQs indicate:
+         * - 0x00: Power on, reset, or bus device reset occurred
+         * - 0x01: Power on occurred
+         * - 0x02: SCSI bus reset occurred
+         * - 0x03: Bus device reset function occurred
+         * - 0x04: Device internal reset
+         * - 0x05: Transceiver mode changed to single-ended
+         * - 0x06: Transceiver mode changed to LVD
+         * - 0x07: I_T nexus loss occurred
+         */
+        const val RESET_OCCURRED = 0x29
+
+        /**
+         * Unit attention condition additional sense code for command queue clear conditions.
+         * It should be safe to handle these conditions with a retry.
+         *
+         * ASCQs indicate:
+         * - 0x00: Commands cleared by another initiator
+         * - 0x01: Commands cleared by power loss notification
+         * - 0x02: Commands cleared by device server
+         * - 0x03: Some commands cleaered by queuing layer event
+         */
+        const val COMMANDS_CLEARED = 0x2F
     }
 }


### PR DESCRIPTION
Hi! I hope you're doing good!

I was working once again on writing QEMU-based end-to-end tests for EtchDroid (which is now easy since GH Actions has nested virtualization support!) and I spotted a new corner case.

If you plug in a USB drive via the QEMU monitor and immediately try to access it, i.e. within 2 seconds, the test unit ready command fails, with sense UNIT ATTENTION, ASC 0x29, ASCQ 0x00 ("Power on, reset, or bus device reset occurred").

I'm currently working around it with a sleep in the tests, but seeing [your note](https://github.com/magnusja/libaums/blob/e71b1fa4992ba6e006e908f69169bdcb98f8bcb3/libaums/src/main/java/me/jahnen/libaums/core/driver/scsi/commands/sense/SenseException.kt#L117-L118) I thought I'd work on making this type of failure recoverable.

I attempted to gather a bunch of unit attention conditions which should be recoverable and make them throw `NotReadyTryAgain` instead of `UnitAttention` so that the block device init method can give it another shot.