### PR TITLE
Fix buffer overflow with dynamic length responses

### DIFF
--- a/libaums/src/main/java/me/jahnen/libaums/core/driver/scsi/ScsiBlockDevice.kt
+++ b/libaums/src/main/java/me/jahnen/libaums/core/driver/scsi/ScsiBlockDevice.kt
@@ -295,8 +295,7 @@ class ScsiBlockDevice(private val usbCommunication: UsbCommunication, private va
                 } while (read < transferLength)
 
                 if (read != transferLength) {
-                    throw IOException("Unexpected command size (" + read + ") on response to "
-                            + command)
+                    throw IOException("Unexpected command size ($read) on response to $command")
                 }
             } else {
                 written = 0

--- a/libaums/src/main/java/me/jahnen/libaums/core/driver/scsi/ScsiBlockDevice.kt
+++ b/libaums/src/main/java/me/jahnen/libaums/core/driver/scsi/ScsiBlockDevice.kt
@@ -19,14 +19,26 @@ package me.jahnen.libaums.core.driver.scsi
 
 import android.util.Log
 import me.jahnen.libaums.core.driver.BlockDeviceDriver
-import me.jahnen.libaums.core.driver.scsi.commands.*
+import me.jahnen.libaums.core.driver.scsi.commands.CommandBlockWrapper
 import me.jahnen.libaums.core.driver.scsi.commands.CommandBlockWrapper.Direction
-import me.jahnen.libaums.core.driver.scsi.commands.sense.*
+import me.jahnen.libaums.core.driver.scsi.commands.CommandStatusWrapper
+import me.jahnen.libaums.core.driver.scsi.commands.ScsiInquiry
+import me.jahnen.libaums.core.driver.scsi.commands.ScsiInquiryResponse
+import me.jahnen.libaums.core.driver.scsi.commands.ScsiRead10
+import me.jahnen.libaums.core.driver.scsi.commands.ScsiReadCapacity
+import me.jahnen.libaums.core.driver.scsi.commands.ScsiReadCapacityResponse
+import me.jahnen.libaums.core.driver.scsi.commands.ScsiTestUnitReady
+import me.jahnen.libaums.core.driver.scsi.commands.ScsiWrite10
+import me.jahnen.libaums.core.driver.scsi.commands.sense.InitRequired
+import me.jahnen.libaums.core.driver.scsi.commands.sense.NotReadyTryAgain
+import me.jahnen.libaums.core.driver.scsi.commands.sense.ScsiRequestSense
+import me.jahnen.libaums.core.driver.scsi.commands.sense.ScsiRequestSenseResponse
+import me.jahnen.libaums.core.driver.scsi.commands.sense.SenseException
 import me.jahnen.libaums.core.usb.PipeException
 import me.jahnen.libaums.core.usb.UsbCommunication
 import java.io.IOException
 import java.nio.ByteBuffer
-import java.util.*
+import java.util.Arrays
 
 /**
  * This class is responsible for handling mass storage devices which follow the
@@ -267,7 +279,8 @@ class ScsiBlockDevice(private val usbCommunication: UsbCommunication, private va
         }
 
         var transferLength = command.dCbwDataTransferLength
-        inBuffer.limit(inBuffer.position() + transferLength)
+        val initialPosition = inBuffer.position()
+        inBuffer.limit(initialPosition + transferLength)
 
         var read = 0
         if (transferLength > 0) {
@@ -277,7 +290,7 @@ class ScsiBlockDevice(private val usbCommunication: UsbCommunication, private va
                     read += usbCommunication.bulkInTransfer(inBuffer)
                     if (command.bCbwDynamicSize) {
                         transferLength = command.dynamicSizeFromPartialResponse(inBuffer)
-                        inBuffer.limit(inBuffer.position() + transferLength)
+                        inBuffer.limit(initialPosition + transferLength)
                     }
                 } while (read < transferLength)
 


### PR DESCRIPTION
Hi again!

When the edge case I fixed with #431 occurs, libaums doesn't actually throw `UnitAttention` but it instead crashes due to a ByteBuffer overflow:

```
Caused by: java.lang.IllegalArgumentException
	at java.nio.Buffer.limit(Buffer.java:290)
	at java.nio.ByteBuffer.limit(ByteBuffer.java:820)
	at me.jahnen.libaums.core.driver.scsi.ScsiBlockDevice.transferOneCommand(ScsiBlockDevice.kt:280)
	at me.jahnen.libaums.core.driver.scsi.ScsiBlockDevice.requestSense(ScsiBlockDevice.kt:222)
	at me.jahnen.libaums.core.driver.scsi.ScsiBlockDevice.handleCommandResult(ScsiBlockDevice.kt:207)
	at me.jahnen.libaums.core.driver.scsi.ScsiBlockDevice.transferCommand(ScsiBlockDevice.kt:155)
	at me.jahnen.libaums.core.driver.scsi.ScsiBlockDevice.transferCommandWithoutDataPhase(ScsiBlockDevice.kt:199)
	at me.jahnen.libaums.core.driver.scsi.ScsiBlockDevice.initAttempt(ScsiBlockDevice.kt:115)
	at me.jahnen.libaums.core.driver.scsi.ScsiBlockDevice.init(ScsiBlockDevice.kt:83)
	at eu.depau.etchdroid.massstorage.EtchDroidUsbMassStorageDevice.setupDevice(EtchDroidUsbMassStorageDevice.kt:218)
	at eu.depau.etchdroid.massstorage.EtchDroidUsbMassStorageDevice.init(EtchDroidUsbMassStorageDevice.kt:188)
	...
```

This is because it does `inBuffer.limit(inBuffer.position() + transferLength)` when computing the new transfer length for commands with dynamic buffer lengths (basically only REQUEST SENSE), but it does so _after_ reading the data into the buffer which also updates `inBuffer.position()`.

This, combined with the fact that SCSI doesn't do any chunking as far as I'm aware of means that `inBuffer.position()` is probably `== transferLength == inBuffer.limit()` already.

In practice, in the REQUEST SENSE crash triggered by the QEMU race condition explained in #431, this means libaums allocates a bytebuffer of 18 bytes, reports that as the allocation size to the device, the device responds with 18 bytes, reporting 10 more bytes in the dynamic length field. Libaums then tries to set the buffer limit to 36 which is obviously wrong.