### PR TITLE
fix: report UsbRequest transfer counts on API 26+

### DIFF
--- a/libaums/src/main/java/me/jahnen/libaums/core/usb/UsbRequestCommunication.kt
+++ b/libaums/src/main/java/me/jahnen/libaums/core/usb/UsbRequestCommunication.kt
@@ -34,7 +34,7 @@ internal class UsbRequestCommunication(
 
         val request = deviceConnection!!.requestWait()
         if (request === outRequest) {
-            return workaroundBuffer.position() - oldPosition
+            return src.position() - oldPosition
         }
 
         throw IOException("requestWait failed! Request: $request")
@@ -106,8 +106,8 @@ internal class UsbRequestCommunication(
         }
 
         val request = deviceConnection!!.requestWait()
-        if (request === outRequest) {
-            return workaroundBuffer.position() - oldPosition
+        if (request === inRequest) {
+            return dest.position() - oldPosition
         }
 
         throw IOException("requestWait failed! Request: $request")


### PR DESCRIPTION
## Summary

- Return API 26+ OUT transfer counts from the queued source buffer.
- Match API 26+ IN completions against `inRequest` and return the queued destination buffer's count.

## Root cause

The API 26+ path queued `src`/`dest` but calculated both results from the unrelated pre-O `workaroundBuffer`. The IN path also compared the completed request with `outRequest`.

## Verification

- `./gradlew :libaums:testDebugUnitTest --stacktrace` (Fedora, JDK 21): passed
- The change is limited to the three incorrect API 26+ expressions; no framework abstraction or unrelated cleanup was added.

Fixes #438
