### PR TITLE
fix: handle unsigned READ CAPACITY(10) values

### DIFF
--- a/libaums/src/main/java/me/jahnen/libaums/core/driver/scsi/ScsiBlockDevice.kt
+++ b/libaums/src/main/java/me/jahnen/libaums/core/driver/scsi/ScsiBlockDevice.kt
@@ -54,7 +54,6 @@ class ScsiBlockDevice(private val usbCommunication: UsbCommunication, private va
 
     override var blockSize: Int = 0
         private set
-    private var lastBlockAddress: Int = 0
 
     private val writeCommand = ScsiWrite10(lun=lun)
     private val readCommand = ScsiRead10(lun=lun)
@@ -67,7 +66,8 @@ class ScsiBlockDevice(private val usbCommunication: UsbCommunication, private va
      *
      * @return The block device size in blocks
      */
-    override val blocks: Long get() = lastBlockAddress.toLong()
+    override var blocks: Long = 0
+        private set
 
     /**
      * Issues a SCSI Inquiry to determine the connected device. After that it is
@@ -132,10 +132,10 @@ class ScsiBlockDevice(private val usbCommunication: UsbCommunication, private va
         inBuffer.clear()
         val readCapacityResponse = ScsiReadCapacityResponse.read(inBuffer)
         blockSize = readCapacityResponse.blockLength
-        lastBlockAddress = readCapacityResponse.logicalBlockAddress
+        blocks = readCapacityResponse.blockCount
 
         Log.i(TAG, "Block size: $blockSize")
-        Log.i(TAG, "Last block address: $lastBlockAddress")
+        Log.i(TAG, "Block count: $blocks")
     }
 
     /**

--- a/libaums/src/main/java/me/jahnen/libaums/core/driver/scsi/commands/ScsiReadCapacityResponse.kt
+++ b/libaums/src/main/java/me/jahnen/libaums/core/driver/scsi/commands/ScsiReadCapacityResponse.kt
@@ -17,6 +17,7 @@
 
 package me.jahnen.libaums.core.driver.scsi.commands
 
+import java.io.IOException
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
@@ -35,12 +36,28 @@ class ScsiReadCapacityResponse private constructor() {
      * Returns the address of the last accessible block on the block device.
      *
      *
-     * The size of the device is then last accessible block + 0!
+     * The number of blocks on the device is the last accessible block + 1.
      *
      * @return The last block address.
      */
     var logicalBlockAddress: Int = 0
         private set
+
+    /**
+     * Returns the number of addressable blocks represented by this response.
+     *
+     * @throws IOException if the device requires READ CAPACITY(16).
+     */
+    @get:Throws(IOException::class)
+    val blockCount: Long
+        get() {
+            val lastBlockAddress = logicalBlockAddress.toLong() and 0xffff_ffffL
+            if (lastBlockAddress == 0xffff_ffffL) {
+                throw IOException("Device requires SCSI READ CAPACITY(16)")
+            }
+            return lastBlockAddress + 1
+        }
+
     /**
      * Returns the size of each block in the block device.
      *

--- a/libaums/src/test/java/me/jahnen/libaums/core/driver/scsi/commands/ScsiReadCapacityResponseTest.java
+++ b/libaums/src/test/java/me/jahnen/libaums/core/driver/scsi/commands/ScsiReadCapacityResponseTest.java
@@ -1,0 +1,44 @@
+package me.jahnen.libaums.core.driver.scsi.commands;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class ScsiReadCapacityResponseTest {
+
+    @Test
+    public void blockCountTreatsLastBlockAddressAsUnsigned() throws IOException {
+        ByteBuffer buffer = ByteBuffer.allocate(8)
+                .order(ByteOrder.BIG_ENDIAN)
+                .putInt(0xEE7752AF)
+                .putInt(512);
+        buffer.flip();
+
+        ScsiReadCapacityResponse response = ScsiReadCapacityResponse.Companion.read(buffer);
+
+        assertEquals(4_000_797_360L, response.getBlockCount());
+    }
+
+    @Test
+    public void blockCountRejectsReadCapacity16Sentinel() {
+        ByteBuffer buffer = ByteBuffer.allocate(8)
+                .order(ByteOrder.BIG_ENDIAN)
+                .putInt(0xFFFFFFFF)
+                .putInt(512);
+        buffer.flip();
+
+        ScsiReadCapacityResponse response = ScsiReadCapacityResponse.Companion.read(buffer);
+
+        try {
+            response.getBlockCount();
+            fail("Expected IOException");
+        } catch (IOException exception) {
+            assertEquals("Device requires SCSI READ CAPACITY(16)", exception.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Interpret the READ CAPACITY(10) last-LBA field as an unsigned 32-bit value.
- Convert the last LBA to an actual block count (`last LBA + 1`).
- Fail clearly on the `0xffffffff` sentinel that requires READ CAPACITY(16).

## Root cause

`ByteBuffer.int` parsed the wire field into a signed `Int`, and `ScsiBlockDevice.blocks` widened that negative value directly to `Long`. This produced a negative capacity for 2 TB-class devices whose last LBA has bit 31 set.

## Verification

- Added regression coverage for `0xee7752af` and the READ CAPACITY(16) sentinel.
- `./gradlew :libaums:testDebugUnitTest --tests me.jahnen.libaums.core.driver.scsi.commands.ScsiReadCapacityResponseTest --stacktrace` (Fedora, JDK 21): passed

Fixes #439
